### PR TITLE
Allow the AWS creds to be specified as configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,13 @@ ember install ember-cli-deploy-elastic-beanstalk
 
 ## A Note on AWS Permissions
 
-This plugin relies on the official AWS SDK to perform uploads to S3. As
+This plugin uses the official AWS SDK to perform uploads to S3. As
 such, it will inherit any credentials you have saved by running `aws
-configure` via the [AWS CLI][aws-cli].
+configure` via the [AWS CLI][aws-cli]. For environments where it is not feasible
+to use  `aws configure` (e.g. your CI environment like Travis), you can additionally
+specify an `accessKeyId` and `secretAccessKey` as a configuration option for this
+ember-cli-deploy plugin in the `deploy.js` file.
+
 
 [aws-cli]: https://aws.amazon.com/cli/
 
@@ -122,6 +126,19 @@ The path to the directory you'd like the FastBoot build to be built in to.
 The path to the zip file that should be created from the `outputPath`.
 
 *Default:* `tmp/fastboot-dist.zip`
+
+### accessKeyId
+
+The AWS access key for the user that has the ability to upload to the `bucket`. If this is left undefined, 
+the normal [AWS SDK credential resolution][5] will take place.
+
+*Default:* `undefined`
+
+### secretAccessKey
+
+The AWS secret for the user that has the ability to upload to the `bucket`. This must be defined when `accessKeyId` is defined.
+
+*Default:* `undefined`
 
 ## Thanks
 

--- a/lib/aws/s3.js
+++ b/lib/aws/s3.js
@@ -5,11 +5,16 @@ const AWS = require('aws-sdk');
 class S3 {
   constructor(options) {
     options = options || {};
-
-    this.s3 = new AWS.S3({
+    let s3Options = {
       apiVersion: '2006-03-01',
       region: options.region
-    });
+    };
+    if (options.accessKeyId && options.secretAccessKey) {
+      s3Options.accessKeyId = options.accessKeyId;
+      s3Options.secretAccessKey = options.secretAccessKey;
+    }
+
+    this.s3 = new AWS.S3(s3Options);
   }
 
   listBuckets() {

--- a/lib/elastic-beanstalk-deploy-plugin.js
+++ b/lib/elastic-beanstalk-deploy-plugin.js
@@ -56,6 +56,8 @@ module.exports = DeployPlugin.extend({
     let region = this.readConfig('region');
     let bucket = this.readConfig('bucket');
     let key = this.readConfig('key');
+    let accessKeyId = this.readConfig('accessKeyId');
+    let secretAccessKey = this.readConfig('secretAccessKey');
 
     let uploadTask = new UploadTask({
       context: context,
@@ -63,7 +65,9 @@ module.exports = DeployPlugin.extend({
       hashedZipPath: context.hashedZipPath,
       region: region,
       bucket: bucket,
-      key: key
+      key: key,
+      accessKeyId: accessKeyId,
+      secretAccessKey: secretAccessKey
     });
 
     return uploadTask.run();

--- a/lib/tasks/upload.js
+++ b/lib/tasks/upload.js
@@ -12,7 +12,10 @@ class UploadTask {
     this.key = options.key;
     this.hashedZipPath = options.hashedZipPath;
     this.hashedZipKey = path.basename(this.hashedZipPath);
-    this.s3 = new S3();
+    this.s3 = new S3({
+      accessKeyId: options.accessKeyId,
+      secretAccessKey: options.secretAccessKey
+    });
   }
 
   run() {


### PR DESCRIPTION
This is for environments like Travis where it is not fasible to setup the aws configure tool.
