### PR TITLE
Add option to exclude matching files from zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ The path to the zip file that should be created from the `outputPath`.
 
 *Default:* `tmp/fastboot-dist.zip`
 
+### filesToExclude
+
+Files that match this pattern will be excluded from the `zip`. For instance to
+exclude files with `.map` extension pass: `'\*.map'`.
+
+*Default:* `''`
+
 ## Thanks
 
 A big thank you to [Luke Melia](https://github.com/lukemelia) for

--- a/lib/elastic-beanstalk-deploy-plugin.js
+++ b/lib/elastic-beanstalk-deploy-plugin.js
@@ -17,7 +17,8 @@ module.exports = DeployPlugin.extend({
   defaultConfig: {
     environment: 'production',
     outputPath: path.join('tmp', 'fastboot-dist'),
-    zipPath: path.join('tmp', 'fastboot-dist.zip')
+    zipPath: path.join('tmp', 'fastboot-dist.zip'),
+    filesToExclude: ''
   },
 
   requiredConfig: ['environment', 'bucket'],
@@ -38,6 +39,7 @@ module.exports = DeployPlugin.extend({
   willUpload(context) {
     let distDir = context.distDir;
     let zipPath = this.readConfig('zipPath');
+    let filesToExclude = this.readConfig('filesToExclude');
 
     let npmInstallTask = new NPMInstallTask({
       log: this.log.bind(this),
@@ -48,7 +50,8 @@ module.exports = DeployPlugin.extend({
       context: context,
       log: this.log.bind(this),
       distDir: distDir,
-      zipPath: zipPath
+      zipPath: zipPath,
+      filesToExclude: filesToExclude
     });
 
     return npmInstallTask.run()

--- a/lib/tasks/zip.js
+++ b/lib/tasks/zip.js
@@ -13,6 +13,7 @@ class ZipTask {
     this.context = options.context;
     this.log = options.log;
     this.distDir = options.distDir;
+    this.filesToExclude = options.filesToExclude;
     this.zipPath = this.distDir.replace(/\/$/, '') + '.zip';
   }
 
@@ -25,6 +26,7 @@ class ZipTask {
   zip() {
     let distDir = this.distDir;
     let zipPath = this.zipPath;
+    let filesToExclude = this.filesToExclude;
     zipPath = path.resolve(zipPath);
 
     this.log('zipping ' + distDir + ' into ' + zipPath, { verbose: true });
@@ -33,7 +35,7 @@ class ZipTask {
       let baseDir = path.basename(distDir);
       let containingDir = path.dirname(distDir);
 
-      let zip = spawn('zip', ['-r', zipPath, baseDir], {
+      let zip = spawn('zip', ['-r', zipPath, baseDir, '-x', filesToExclude], {
         cwd: containingDir
       });
 


### PR DESCRIPTION
Useful when need to generate source maps in production (e.g. for upload to [sentry.io](sentry.io)), but need to exclude them from deployment to S3 and public access to app's source code.