### PR TITLE
Allow to skip npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ The path to the zip file that should be created from the `outputPath`.
 
 *Default:* `tmp/fastboot-dist.zip`
 
+### skipNpmInstall
+
+Does not run `npm install` as part of the build procedure if set to `true`.
+
+*Default:* `false`
+
 ## Thanks
 
 A big thank you to [Luke Melia](https://github.com/lukemelia) for

--- a/lib/elastic-beanstalk-deploy-plugin.js
+++ b/lib/elastic-beanstalk-deploy-plugin.js
@@ -17,7 +17,8 @@ module.exports = DeployPlugin.extend({
   defaultConfig: {
     environment: 'production',
     outputPath: path.join('tmp', 'fastboot-dist'),
-    zipPath: path.join('tmp', 'fastboot-dist.zip')
+    zipPath: path.join('tmp', 'fastboot-dist.zip'),
+    skipNpmInstall: false
   },
 
   requiredConfig: ['environment', 'bucket'],
@@ -38,6 +39,7 @@ module.exports = DeployPlugin.extend({
   willUpload(context) {
     let distDir = context.distDir;
     let zipPath = this.readConfig('zipPath');
+    let skipNpmInstall = this.readConfig('skipNpmInstall');
 
     let npmInstallTask = new NPMInstallTask({
       log: this.log.bind(this),
@@ -51,7 +53,9 @@ module.exports = DeployPlugin.extend({
       zipPath: zipPath
     });
 
-    return npmInstallTask.run()
+    let promise = skipNpmInstall ? Promise.resolve('') : npmInstallTask.run();
+
+    return promise
       .then(() => zipTask.run());
   },
 


### PR DESCRIPTION
Allows to significantly speed up deployment time by not installing, deflating, and uploading `node_modules`.

I use [fastboot-s3-downloader](https://github.com/tomdale/fastboot-s3-downloader) and it runs `npm install` server-side anyway.